### PR TITLE
Config specs and refactoring

### DIFF
--- a/apigee_cli.gemspec
+++ b/apigee_cli.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'pry', '~> 0.10.1'
   spec.add_development_dependency 'rspec', '~> 3.1'
-  spec.add_development_dependency 'rack-test'
-  spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'rack-test', '~> 0.6.3'
+  spec.add_development_dependency 'webmock', '~> 1.21.0'
 end

--- a/lib/apigee_cli/cli/app_config.rb
+++ b/lib/apigee_cli/cli/app_config.rb
@@ -60,12 +60,12 @@ class AppConfig < ThorCli
 
     if entry_name
       confirm = yes? "Are you sure you want to delete #{entry_name} from #{config_name} in #{environment} environment? [y/n]"
-      return if !confirm
+      exit if !confirm
 
       remove_entry(config_set, config_name, entry_name)
     else
       confirm = yes? "Are you sure you want to delete #{config_name} from #{environment} environment? [y/n]"
-      return if !confirm
+      exit if !confirm
 
       remove_config(config_set, config_name)
     end

--- a/lib/apigee_cli/cli/app_config.rb
+++ b/lib/apigee_cli/cli/app_config.rb
@@ -42,8 +42,7 @@ class AppConfig < ThorCli
       say "Overwriting existing config #{config_name} in #{environment} environment"
     end
 
-    response       = config_set.read_config(config_name)
-    updated_config = Hashie::Mash.new(response[ApigeeCli::ConfigSet::ENTRY_KEY])
+    updated_config = config_set.read_config(config_name)[ApigeeCli::ConfigSet::ENTRY_KEY]
 
     render_config(config_name, updated_config, changed_keys)
   end

--- a/lib/apigee_cli/cli/app_config.rb
+++ b/lib/apigee_cli/cli/app_config.rb
@@ -94,8 +94,7 @@ class AppConfig < ThorCli
     def remove_config(config_set, config_name)
       begin
         response = Hashie::Mash.new(config_set.remove_config(config_name))
-        say "Config #{config_name} has been deleted from #{environment} environment", :red
-        render_config(config_name, response[ApigeeCli::ConfigSet::ENTRY_KEY])
+        say "Config [#{config_name}] has been deleted from [#{environment}] environment", :red
       rescue RuntimeError => e
         render_error(e)
       end
@@ -104,8 +103,7 @@ class AppConfig < ThorCli
     def remove_entry(config_set, config_name, entry_name)
       begin
         response = Hashie::Mash.new(config_set.remove_entry(config_name, entry_name))
-        say "Entry #{entry_name} has been deleted from #{config_name} in #{environment} environment", :red
-        render_entry(response)
+        say "Entry [#{entry_name}] has been deleted from [#{config_name}] in [#{environment}] environment", :red
       rescue RuntimeError => e
         render_error(e)
       end

--- a/lib/apigee_cli/cli/app_config.rb
+++ b/lib/apigee_cli/cli/app_config.rb
@@ -37,9 +37,9 @@ class AppConfig < ThorCli
     if result == :new
       say "Creating new config for [#{config_name}] in [#{environment}] environment"
     elsif result == :existing
-      say "Adding new keys #{changed_keys} to config #{config_name} in #{environment} environment"
+      say "Adding new keys #{changed_keys} to config [#{config_name}] in [#{environment}] environment"
     elsif result == :overwritten
-      say "Overwriting existing config #{config_name} in #{environment} environment"
+      say "Overwriting existing config [#{config_name}] in [#{environment}] environment"
     end
 
     updated_config = config_set.read_config(config_name)[ApigeeCli::ConfigSet::ENTRY_KEY]

--- a/lib/apigee_cli/cli/app_config.rb
+++ b/lib/apigee_cli/cli/app_config.rb
@@ -1,3 +1,5 @@
+require 'apigee_cli/cli/thor_cli'
+
 class AppConfig < ThorCli
   namespace 'config'
   default_task :list

--- a/lib/apigee_cli/cli/app_config.rb
+++ b/lib/apigee_cli/cli/app_config.rb
@@ -80,8 +80,12 @@ class AppConfig < ThorCli
   private
 
     def pull_list(config_set)
-      response = Hashie::Mash.new(config_set.list_configs)
-      render_list(response[MAP_KEY])
+      begin
+        response = Hashie::Mash.new(config_set.list_configs)
+        render_list(response[MAP_KEY])
+      rescue RuntimeError => e
+        render_error(e)
+      end
     end
 
     def pull_config(config_set, config_name)

--- a/lib/apigee_cli/cli/resource.rb
+++ b/lib/apigee_cli/cli/resource.rb
@@ -55,6 +55,8 @@ class Resource < ThorCli
         render_error(e)
         exit
       end
+    else
+      exit
     end
   end
 

--- a/lib/apigee_cli/cli/resource.rb
+++ b/lib/apigee_cli/cli/resource.rb
@@ -4,9 +4,6 @@ class Resource < ThorCli
   namespace 'resource'
   default_task :list
 
-  RESOURCE_FILE_KEY = 'resourceFile'
-  DEFAULT_RESOURCE_TYPE = 'jsc'
-
   desc 'list', 'List resource files'
   option :name, type: :string
   def list
@@ -15,7 +12,7 @@ class Resource < ThorCli
     resource = ApigeeCli::ResourceFile.new(environment)
 
     if name
-      response = resource.read(name, DEFAULT_RESOURCE_TYPE)
+      response = resource.read(name, ApigeeCli::ResourceFile::DEFAULT_RESOURCE_TYPE)
       say response
     else
       pull_list(resource)
@@ -32,7 +29,7 @@ class Resource < ThorCli
     resource = ApigeeCli::ResourceFile.new(environment)
 
     files.each do |file|
-      result = resource.upload file, DEFAULT_RESOURCE_TYPE, "jsc/#{file}"
+      result = resource.upload file, ApigeeCli::ResourceFile::DEFAULT_RESOURCE_TYPE, "jsc/#{file}"
       if result == :overwritten
         say "Deleting current resource for #{file}", :red
       elsif result == :new_file
@@ -53,7 +50,7 @@ class Resource < ThorCli
     if confirm
       begin
         say "Deleting current resource for #{name}", :red
-        resource.remove(name, DEFAULT_RESOURCE_TYPE)
+        resource.remove(name, ApigeeCli::ResourceFile::DEFAULT_RESOURCE_TYPE)
       rescue RuntimeError => e
         render_error(e)
         exit
@@ -65,7 +62,7 @@ class Resource < ThorCli
 
     def pull_list(resource)
       response = Hashie::Mash.new(resource.all)
-      render_list(response[RESOURCE_FILE_KEY])
+      render_list(response[ApigeeCli::ResourceFile::RESOURCE_FILE_KEY])
     end
 
     def render_list(resource_files)

--- a/lib/apigee_cli/config_set.rb
+++ b/lib/apigee_cli/config_set.rb
@@ -5,20 +5,6 @@ module ApigeeCli
     ENTRY_KEY           = 'entry'
     DEFAULT_CONFIG_NAME = 'configuration'
 
-    class << self
-      def parse_filename(config_filename)
-        filename_parts = config_filename.gsub(/.json$/,'').split('_')
-
-        OpenStruct.new(
-          {
-            filename: config_filename,
-            environment: filename_parts.last,
-            name: filename_parts.slice(0, filename_parts.length - 1).join('_')
-          }
-        )
-      end
-    end
-
     def base_url
       "https://api.enterprise.apigee.com/v1/o/#{org}/environments/#{environment}/keyvaluemaps"
     end

--- a/lib/apigee_cli/config_set.rb
+++ b/lib/apigee_cli/config_set.rb
@@ -63,14 +63,14 @@ module ApigeeCli
         response = Hashie::Mash.new(read_config(config_name))
         if overwrite
           result = :overwritten
-          update_config(config_name, data)
         else
           orig_keys = response[ENTRY_KEY].map(&:name)
           data.reject! { |pair| orig_keys.include?(pair['name']) }
 
           result = :existing
-          update_config(config_name, data)
         end
+
+        update_config(config_name, data)
       rescue RuntimeError => e
         if e.message.include?('keyvaluemap_doesnt_exist')
           result = :new

--- a/lib/apigee_cli/resource_file.rb
+++ b/lib/apigee_cli/resource_file.rb
@@ -1,5 +1,9 @@
 module ApigeeCli
   class ResourceFile < Base
+
+    RESOURCE_FILE_KEY = 'resourceFile'
+    DEFAULT_RESOURCE_TYPE = 'jsc'
+
     def base_url
       "https://api.enterprise.apigee.com/v1/organizations/#{org}/resourcefiles"
     end

--- a/spec/cli/app_config_spec.rb
+++ b/spec/cli/app_config_spec.rb
@@ -43,6 +43,16 @@ describe AppConfig do
         "  key_b: value_b"
       ]
     end
+
+    specify 'when config does not exist on Apigee Server, an error is rendered' do
+      app_config = AppConfig.new([])
+      app_config.shell = ShellRecorder.new
+      allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:list_configs).and_raise("Map does not exist")
+
+      app_config.invoke(:list)
+
+      expect(app_config.shell.printed).to eq ["Map does not exist"]
+    end
   end
 
   describe 'apigee config push' do

--- a/spec/cli/app_config_spec.rb
+++ b/spec/cli/app_config_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'apigee_cli/cli/app_config'
+
+describe AppConfig do
+  describe 'apigee config list' do
+    it 'prints all the key value maps'
+    it 'prints the key value pairs for --config_name'
+  end
+
+  describe 'apigee config push' do
+    context 'when key value map with --config_name exists' do
+      it 'creates a new key value map'
+    end
+
+    context 'when key value map with --config_name exists' do
+      it 'allows you to push up a new key value pair'
+      specify 'when a key value pair exists'
+    end
+  end
+
+  describe 'apigee config delete' do
+  end
+end

--- a/spec/cli/app_config_spec.rb
+++ b/spec/cli/app_config_spec.rb
@@ -127,5 +127,41 @@ describe AppConfig do
   end
 
   describe 'apigee config delete' do
+    let(:config_name) { ApigeeCli::ConfigSet::DEFAULT_CONFIG_NAME }
+    before do
+      allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:list_configs).and_return({
+        "keyValueMap" => [
+          { "entry" => [ { "name" => "key_one", "value" => "value_one" },
+                         { "name" => "key_two", "value" => "value_two" }
+                       ],
+            "name" => "#{config_name}"
+          }
+        ]
+      })
+    end
+
+    context 'when user gives permission' do
+      it 'deletes --config_name=configuration key value map by default' do
+        app_config = AppConfig.new([])
+        app_config.shell = ShellRecorder.new
+        allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:remove_config).with(config_name).and_return({
+          "entry" => [],
+          "name" => "#{config_name}"
+        })
+        allow(app_config.shell).to receive(:yes?).and_return(true)
+
+        app_config.invoke(:delete)
+
+        expect(app_config.shell.printed).to include "Config [#{config_name}] has been deleted from [test] environment"
+      end
+
+      it 'deletes --entry_name entry from --config_name key value map'
+      it 'renders an error when there was an error updating a config on the server'
+    end
+
+    context 'when user doesn\'t give permission' do
+      it 'doesn\'t delete the --config_name key value map'
+      it 'doesn\'t delete the --entry_name entry from --config_name key value map'
+    end
   end
 end

--- a/spec/cli/app_config_spec.rb
+++ b/spec/cli/app_config_spec.rb
@@ -56,15 +56,28 @@ describe AppConfig do
   end
 
   describe 'apigee config push' do
+    let(:config_name) { 'test_config' }
+
+    before do
+      allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:read_config).with(config_name).and_return({
+        "entry" => [ { "name" => "key_a", "value" => "value_a" },
+                     { "name" => "key_b", "value" => "value_b" }
+                   ],
+        "name" => config_name
+      })
+    end
+
     context 'when key value map with --config_name doesn\'t exist' do
-      before do
-        allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:read_config).and_raise(RuntimeError, "keyvaluemap_doesnt_exist")
-      end
-
       it 'creates a new key value map' do
-        app_config = AppConfig.new([], config_name: 'teehee')
+        app_config = AppConfig.new([], config_name: config_name)
         app_config.shell = ShellRecorder.new
+        allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:add_config).and_return([
+          :new, [:key_one]
+        ])
 
+        app_config.invoke(:push)
+
+        expect(app_config.shell.printed).to include "Creating new config for [#{config_name}] in [test] environment"
       end
     end
 

--- a/spec/cli/app_config_spec.rb
+++ b/spec/cli/app_config_spec.rb
@@ -56,13 +56,26 @@ describe AppConfig do
   end
 
   describe 'apigee config push' do
-    context 'when key value map with --config_name exists' do
-      it 'creates a new key value map'
+    context 'when key value map with --config_name doesn\'t exist' do
+      before do
+        allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:read_config).and_raise(RuntimeError, "keyvaluemap_doesnt_exist")
+      end
+
+      it 'creates a new key value map' do
+        app_config = AppConfig.new([], config_name: 'teehee')
+        app_config.shell = ShellRecorder.new
+
+      end
     end
 
     context 'when key value map with --config_name exists' do
-      it 'allows you to push up a new key value pair'
-      specify 'when a key value pair exists'
+      context 'when a key value pair exists' do
+        it 'gets replaced with new key value pair if --overwrite=true'
+      end
+
+      context 'when a key value pair doesn\'t exist' do
+        it 'gets added to the key value map'
+      end
     end
   end
 

--- a/spec/cli/app_config_spec.rb
+++ b/spec/cli/app_config_spec.rb
@@ -3,8 +3,46 @@ require 'apigee_cli/cli/app_config'
 
 describe AppConfig do
   describe 'apigee config list' do
-    it 'prints all the key value maps'
-    it 'prints the key value pairs for --config_name'
+    it 'prints all the key value maps' do
+      app_config = AppConfig.new([])
+      app_config.shell = ShellRecorder.new
+      allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:list_configs).and_return({
+        "keyValueMap" => [
+          { "entry" => [ { "name" => "key_one", "value" => "value_one" },
+                         { "name" => "key_two", "value" => "value_two" }
+                       ],
+            "name" => "configuration"
+          }
+        ]
+      })
+
+      app_config.invoke(:list)
+
+      expect(app_config.shell.printed).to eq [
+        "Environment: test, Config Name: configuration",
+        "  key_one: value_one",
+        "  key_two: value_two"
+      ]
+    end
+
+    it 'prints the key value pairs for --config_name' do
+      app_config = AppConfig.new([], config_name: 'teehee')
+      app_config.shell = ShellRecorder.new
+      allow_any_instance_of(ApigeeCli::ConfigSet).to receive(:read_config).with('teehee').and_return({
+        "entry" => [ { "name" => "key_a", "value" => "value_a" },
+                     { "name" => "key_b", "value" => "value_b" }
+                   ],
+        "name" => "teehee"
+      })
+
+      app_config.invoke(:list)
+
+      expect(app_config.shell.printed).to eq [
+        "Environment: test, Config Name: teehee",
+        "  key_a: value_a",
+        "  key_b: value_b"
+      ]
+    end
   end
 
   describe 'apigee config push' do

--- a/spec/cli/resource_spec.rb
+++ b/spec/cli/resource_spec.rb
@@ -82,13 +82,16 @@ describe Resource do
     end
 
     context 'when user gives permission to delete the file' do
+      before do
+        allow_any_instance_of(ShellRecorder).to receive(:yes?).and_return true
+      end
+
       it 'deletes the file if it exists' do
         resource = Resource.new([], name: 'test3.js')
         resource.shell = ShellRecorder.new
         allow_any_instance_of(ApigeeCli::ResourceFile).to receive(:remove)
           .with('test3.js', 'jsc')
           .and_return("Deleted")
-        allow(resource.shell).to receive(:yes?).and_return(true)
 
         resource.invoke(:delete)
 
@@ -101,7 +104,6 @@ describe Resource do
         resource = Resource.new([], name: 'test3.js')
         resource.shell = ShellRecorder.new
         allow_any_instance_of(ApigeeCli::ResourceFile).to receive(:remove).and_raise("Resource already exists")
-        allow(resource.shell).to receive(:yes?).and_return(true)
 
         expect {
           resource.invoke(:delete)
@@ -112,14 +114,19 @@ describe Resource do
     end
 
     context 'when user doesn\'t give permission to delete the file' do
+      before do
+        allow_any_instance_of(ShellRecorder).to receive(:yes?).and_return false
+      end
+
       it 'doesn\'t delete the file' do
         resource = Resource.new([], name: 'test3.js')
         resource.shell = ShellRecorder.new
-        allow(resource.shell).to receive(:yes?).and_return(false)
 
         expect_any_instance_of(ApigeeCli::ResourceFile).to_not receive(:remove)
 
-        resource.invoke(:delete)
+        expect {
+          resource.invoke(:delete)
+        }.to raise_error SystemExit
       end
     end
   end


### PR DESCRIPTION
Specs for `apigee config *`, also did a bit of refactoring to closely match our implementation of `apigee resource *`

The main meat of logic lies in `apigee config push` and is similar to the way we handle `apigee resource upload`.

@bellycard/platform @darbyfrey 
