### PR TITLE
Upload individual resource file

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ C. Resource Files on Apigee Server
     # Upload resource files from resource_folder
     $ apigee resource upload --folder=jsc
 
+    # Upload specific resource file from resource folder
+    $ apigee resource upload --folder=jsc --name=testing.js
+
 #### apigee resource delete
 
     # Delete resource file of resource_name

--- a/apigee_cli.gemspec
+++ b/apigee_cli.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["darbyfrey@gmail.com", "wongyumin@gmail.com"]
   spec.summary       = %q{A CLI for Apigee}
   spec.description   = %q{A CLI for Apigee}
-  spec.homepage      = ""
+  spec.homepage      = "https://tech.bellycard.com"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/lib/apigee_cli/cli/resource.rb
+++ b/lib/apigee_cli/cli/resource.rb
@@ -21,10 +21,16 @@ class Resource < ThorCli
 
   desc 'upload', 'Upload resource files'
   option :folder, type: :string, required: true
+  option :name, type: :string
   def upload
     folder = options[:folder]
+    name = options[:name]
 
-    files = Dir.entries(folder).select{ |f| f =~ /.js$/ }
+    if name
+      files = Dir.entries(folder).select{ |f| f =~ /#{name}$/ }
+    else
+      files = Dir.entries(folder).select{ |f| f =~ /.js$/ }
+    end
 
     resource = ApigeeCli::ResourceFile.new(environment)
 

--- a/lib/apigee_cli/version.rb
+++ b/lib/apigee_cli/version.rb
@@ -1,3 +1,3 @@
 module ApigeeCli
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/spec/cli/resource_spec.rb
+++ b/spec/cli/resource_spec.rb
@@ -70,6 +70,17 @@ describe Resource do
         "Deleting current resource for test2.js"
       ]
     end
+
+    specify 'when --name is specified, it only uploads that file to the Apigee server' do
+      resource = Resource.new([], folder: File.expand_path('../fixtures', __dir__), name: 'test.js')
+      resource.shell = ShellRecorder.new
+      allow_any_instance_of(ApigeeCli::ResourceFile).to receive(:upload).and_return(:new_file)
+
+      resource.invoke(:upload)
+
+      expect(resource.shell.printed).to_not include 'Creating resource for test.txt'
+      expect(resource.shell.printed).to eq ["Creating resource for test.js"]
+    end
   end
 
   describe 'apigee resource delete' do

--- a/spec/cli/resource_spec.rb
+++ b/spec/cli/resource_spec.rb
@@ -78,7 +78,6 @@ describe Resource do
 
       resource.invoke(:upload)
 
-      expect(resource.shell.printed).to_not include 'Creating resource for test.txt'
       expect(resource.shell.printed).to eq ["Creating resource for test.js"]
     end
   end


### PR DESCRIPTION
Adding an option to upload an individual resource file instead of having to upload all the (mostly unchanged) files in the directory 

@bellycard/platform 
